### PR TITLE
Support font dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This native Node.js module allows you to manipulate fonts on different OSes.
 
 ## API
 
-### fontManager.getAvailableFonts([params]) **_macOS_**
+### fontManager.getAvailableFonts([params]) **_Windows_ _macOS_**
 
 * `params` Object (optional)
   * `traits` Array<String> - An array of strings specifying what traits to filter the available system fonts for; must be one of: 'bold', 'compressed', 'condensed', 'expanded', 'fixedPitch', 'italic', 'narrow', 'nonStandardCharacterSet', 'poster', 'smallCaps', 'unbold', 'unitalic'.
@@ -64,7 +64,7 @@ console.log(availableFontFamilies)
 */
 ```
 
-### fontManager.getAvailableMembersOfFontFamily(fontFamily) **_macOS_**
+### fontManager.getAvailableMembersOfFontFamily(fontFamily) **_Windows_ _macOS_**
 
 * `family` String - The name of a font family, like one returned in `availableFontFamilies()`.
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-const fontManager = require('./build/Release/font_manager.node')
+const { EventEmitter } = require('events');
+const fontManager = require('./build/Release/font_manager.node');
 
 function getAvailableFonts(params = {}) {
   const options = [
@@ -37,17 +38,18 @@ function getAvailableMembersOfFontFamily(fontFamily) {
   return fontManager.getAvailableMembersOfFontFamily.call(this, fontFamily)
 }
 
-function showFontPanel(showStyles = false, title = null) {
-  if (typeof showStyles !== 'boolean') {
-    throw new TypeError('showStyles must be a boolean')
+class FontPanel extends EventEmitter {
+  show(options = {}) {
+    if (options.showStyles !== undefined && typeof options.showStyles !== 'boolean') {
+      throw new TypeError('showStyles must be a boolean')
+    }
+    return fontManager.showFontPanel.call(this, this.emit.bind(this), options);
   }
-
-  return fontManager.showFontPanel.call(this, showStyles, title || "")
 }
 
 module.exports = {
   getAvailableFonts,
   getAvailableMembersOfFontFamily,
   getAvailableFontFamilies: fontManager.getAvailableFontFamilies,
-  showFontPanel,
+  FontPanel,
 }

--- a/index.js
+++ b/index.js
@@ -43,7 +43,16 @@ class FontPanel extends EventEmitter {
     if (options.showStyles !== undefined && typeof options.showStyles !== 'boolean') {
       throw new TypeError('showStyles must be a boolean')
     }
-    return fontManager.showFontPanel.call(this, this.emit.bind(this), options);
+    const { parent } = options;
+    const o = { ...options };
+    if (parent) {
+      if (parent.getNativeWindowHandle) {
+        o.parent = parent.getNativeWindowHandle();
+      } else {
+        delete o.parent;
+      }
+    }
+    return fontManager.showFontPanel.call(this, this.emit.bind(this), o);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -37,12 +37,12 @@ function getAvailableMembersOfFontFamily(fontFamily) {
   return fontManager.getAvailableMembersOfFontFamily.call(this, fontFamily)
 }
 
-function showFontPanel(showStyles = false) {
+function showFontPanel(showStyles = false, title = null) {
   if (typeof showStyles !== 'boolean') {
     throw new TypeError('showStyles must be a boolean')
   }
 
-  fontManager.showFontPanel.call(this, showStyles)
+  return fontManager.showFontPanel.call(this, showStyles, title || "")
 }
 
 module.exports = {

--- a/src/gtk_font_manager.cc
+++ b/src/gtk_font_manager.cc
@@ -2,11 +2,21 @@
 // #include <gtk/gtk.h>
 
 void ShowFontPanel(const Napi::CallbackInfo &info) {
-  // std::string title = info[0].As<Napi::String>().Utf8Value();
+  Napi::Env env = info.Env();
+  Napi::Function emit = info[0].As<Napi::Function>();
+  Napi::Object options = info[1].As<Napi::Object>();
+
+  std::string title;
+  Napi::Value titleValue = options.Get("title");
+  if (titleValue.IsString())
+      title = titleValue.As<Napi::String>().Utf8Value();
+
+  Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
 
   // GtkFontChooser *fd = (GtkFontChooser*)gtk_font_chooser_dialog_new (title.c_str(), NULL);
 
   // gtk_widget_show(GTK_WIDGET(fd));
+
   return deferred.Promise();
 }
 

--- a/src/gtk_font_manager.cc
+++ b/src/gtk_font_manager.cc
@@ -1,12 +1,13 @@
 #include <napi.h>
-#include <gtk/gtk.h>
+// #include <gtk/gtk.h>
 
 void ShowFontPanel(const Napi::CallbackInfo &info) {
-  std::string title = info[0].As<Napi::String>().Utf8Value();
+  // std::string title = info[0].As<Napi::String>().Utf8Value();
 
-  GtkFontChooser *fd = (GtkFontChooser*)gtk_font_chooser_dialog_new (title.c_str(), NULL);
+  // GtkFontChooser *fd = (GtkFontChooser*)gtk_font_chooser_dialog_new (title.c_str(), NULL);
 
-  gtk_widget_show(GTK_WIDGET(fd));
+  // gtk_widget_show(GTK_WIDGET(fd));
+  return deferred.Promise();
 }
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {

--- a/src/gtk_font_manager.cc
+++ b/src/gtk_font_manager.cc
@@ -1,7 +1,7 @@
 #include <napi.h>
 // #include <gtk/gtk.h>
 
-void ShowFontPanel(const Napi::CallbackInfo &info) {
+Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::Function emit = info[0].As<Napi::Function>();
   Napi::Object options = info[1].As<Napi::Object>();

--- a/src/mac_font_manager.mm
+++ b/src/mac_font_manager.mm
@@ -39,34 +39,34 @@ NSFontTraitMask ParseTraits(Napi::Array traits) {
 }
 
 Napi::Array BuildTraits(Napi::Env env, NSFontTraitMask mask) {
-    std::vector<std::string> traits;
-    if ((NSBoldFontMask & mask) != 0)
-        traits.push_back("bold");
-    if ((NSCondensedFontMask & mask) != 0)
-        traits.push_back("condensed");
-    if ((NSExpandedFontMask & mask) != 0)
-        traits.push_back("expanded");
-    if ((NSFixedPitchFontMask & mask) != 0)
-        traits.push_back("fixedPitch");
-    if ((NSItalicFontMask & mask) != 0)
-        traits.push_back("italic");
-    if ((NSNarrowFontMask & mask) != 0)
-        traits.push_back("narrow");
-    if ((NSNonStandardCharacterSetFontMask & mask) != 0)
-        traits.push_back("nonStandardCharacterSet");
-    if ((NSPosterFontMask & mask) != 0)
-        traits.push_back("poster");
-    if ((NSSmallCapsFontMask & mask) != 0)
-        traits.push_back("smallCaps");
-    if ((NSUnboldFontMask & mask) != 0)
-        traits.push_back("unbold");
-    if ((NSUnitalicFontMask & mask) != 0)
-        traits.push_back("unitalic");
-    Napi::Array t = Napi::Array::New(env, traits.size());
-    for (size_t i = 0; i < traits.size(); i++)
-        t[i] = traits[i];
+  std::vector<std::string> traits;
+  if ((NSBoldFontMask & mask) != 0)
+    traits.push_back("bold");
+  if ((NSCondensedFontMask & mask) != 0)
+    traits.push_back("condensed");
+  if ((NSExpandedFontMask & mask) != 0)
+    traits.push_back("expanded");
+  if ((NSFixedPitchFontMask & mask) != 0)
+    traits.push_back("fixedPitch");
+  if ((NSItalicFontMask & mask) != 0)
+    traits.push_back("italic");
+  if ((NSNarrowFontMask & mask) != 0)
+    traits.push_back("narrow");
+  if ((NSNonStandardCharacterSetFontMask & mask) != 0)
+    traits.push_back("nonStandardCharacterSet");
+  if ((NSPosterFontMask & mask) != 0)
+    traits.push_back("poster");
+  if ((NSSmallCapsFontMask & mask) != 0)
+    traits.push_back("smallCaps");
+  if ((NSUnboldFontMask & mask) != 0)
+    traits.push_back("unbold");
+  if ((NSUnitalicFontMask & mask) != 0)
+    traits.push_back("unitalic");
+  Napi::Array t = Napi::Array::New(env, traits.size());
+  for (size_t i = 0; i < traits.size(); i++)
+    t[i] = traits[i];
 
-    return t;
+  return t;
 }
 
 /***** EXPORTED FUNCTIONS *****/
@@ -141,25 +141,25 @@ Napi::Array GetAvailableMembersOfFontFamily(const Napi::CallbackInfo &info) {
 NSFont *BuildFont(Napi::Object options) {
   Napi::Value pointSizeValue = options.Get("pointSize");
   if (pointSizeValue.IsNumber()) {
-      NSMutableDictionary<NSFontDescriptorAttributeName, id> *attrs = [NSMutableDictionary dictionaryWithCapacity:0];
-      Napi::Value nameValue = options.Get("name");
-      if (nameValue.IsString()) {
-        std::string s(nameValue.As<Napi::String>().Utf8Value());
-        attrs[NSFontNameAttribute] = [NSString stringWithUTF8String:s.c_str()];
-      }
-      Napi::Value familyValue = options.Get("family");
-      if (familyValue.IsString()) {
-        std::string s(familyValue.As<Napi::String>().Utf8Value());
-        attrs[NSFontFamilyAttribute] = [NSString stringWithUTF8String:s.c_str()];
-      }
-      Napi::Value traits = options.Get("traits");
-      if (traits.IsArray()) {
-        NSFontTraitMask mask = ParseTraits(traits.As<Napi::Array>());
-        attrs[NSFontSymbolicTrait] = [NSNumber numberWithUnsignedInt:mask];
-      }
-      NSFontDescriptor *descr = [NSFontDescriptor fontDescriptorWithFontAttributes:attrs];
-      CGFloat size = pointSizeValue.As<Napi::Number>().FloatValue();
-      return [NSFont fontWithDescriptor:descr size:size];
+    NSMutableDictionary<NSFontDescriptorAttributeName, id> *attrs = [NSMutableDictionary dictionaryWithCapacity:0];
+    Napi::Value nameValue = options.Get("name");
+    if (nameValue.IsString()) {
+      std::string s(nameValue.As<Napi::String>().Utf8Value());
+      attrs[NSFontNameAttribute] = [NSString stringWithUTF8String:s.c_str()];
+    }
+    Napi::Value familyValue = options.Get("family");
+    if (familyValue.IsString()) {
+      std::string s(familyValue.As<Napi::String>().Utf8Value());
+      attrs[NSFontFamilyAttribute] = [NSString stringWithUTF8String:s.c_str()];
+    }
+    Napi::Value traits = options.Get("traits");
+    if (traits.IsArray()) {
+      NSFontTraitMask mask = ParseTraits(traits.As<Napi::Array>());
+      attrs[NSFontSymbolicTrait] = [NSNumber numberWithUnsignedInt:mask];
+    }
+    NSFontDescriptor *descr = [NSFontDescriptor fontDescriptorWithFontAttributes:attrs];
+    CGFloat size = pointSizeValue.As<Napi::Number>().FloatValue();
+    return [NSFont fontWithDescriptor:descr size:size];
   }
   return nil;
 }
@@ -177,40 +177,39 @@ NSFont *BuildFont(Napi::Object options) {
 
 - (nullable instancetype)initWithEmitter:(Napi::Function*)emit
 {
-    self = [super init];
-    if (self != nil)
-    {
-        self.emit = new Napi::FunctionReference;
-        *self.emit = Napi::Persistent(*emit);
-        self.font = [NSFont boldSystemFontOfSize:12];
-    }
+  self = [super init];
+  if (self != nil) {
+    self.emit = new Napi::FunctionReference;
+    *self.emit = Napi::Persistent(*emit);
+    self.font = [NSFont boldSystemFontOfSize:12];
+  }
 
-    return self;
+  return self;
 }
 
 - (void)dealloc
 {
-    if (self.emit) {
-        Napi::Env env = self.emit->Env();
-        Napi::HandleScope scope(env);
-        delete self.emit;
-    }
-    [super dealloc];
+  if (self.emit) {
+    Napi::Env env = self.emit->Env();
+    Napi::HandleScope scope(env);
+    delete self.emit;
+  }
+  [super dealloc];
 }
 
 - (void)changeFont:(id)sender
 {
-    self.font = [sender convertFont:self.font];
+  self.font = [sender convertFont:self.font];
 
-    Napi::Env env = self.emit->Env();
-    Napi::HandleScope scope(env);
-    Napi::Object obj = Napi::Object::New(env);
-    obj.Set(Napi::String::New(env, "family"), Napi::String::New(env, [self.font.familyName UTF8String]));
-    obj.Set(Napi::String::New(env, "name"), Napi::String::New(env, [self.font.fontName UTF8String]));
-    obj.Set(Napi::String::New(env, "pointSize"), Napi::Number::New(env, self.font.pointSize));
-    NSFontTraitMask mask = self.font.fontDescriptor.symbolicTraits;
-    obj.Set(Napi::String::New(env, "traits"), BuildTraits(env, mask));
-    self.emit->Call({Napi::String::New(env, "fontSelected"), obj});
+  Napi::Env env = self.emit->Env();
+  Napi::HandleScope scope(env);
+  Napi::Object obj = Napi::Object::New(env);
+  obj.Set(Napi::String::New(env, "family"), Napi::String::New(env, [self.font.familyName UTF8String]));
+  obj.Set(Napi::String::New(env, "name"), Napi::String::New(env, [self.font.fontName UTF8String]));
+  obj.Set(Napi::String::New(env, "pointSize"), Napi::Number::New(env, self.font.pointSize));
+  NSFontTraitMask mask = self.font.fontDescriptor.symbolicTraits;
+  obj.Set(Napi::String::New(env, "traits"), BuildTraits(env, mask));
+  self.emit->Call({Napi::String::New(env, "fontSelected"), obj});
 }
 
 @end
@@ -223,11 +222,11 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
 
   Napi::Function emit(info[0].As<Napi::Function>());
   Napi::Object options = info[1].As<Napi::Object>();
-  bool show_styles = options.Get("showStyle").As<Napi::Boolean>().Value();
+  bool show_styles = options.Get("showStyle").ToBoolean().Value();
   std::string title;
   Napi::Value titleValue = options.Get("title");
   if (titleValue.IsString())
-      title = titleValue.As<Napi::String>().Utf8Value();
+    title = titleValue.As<Napi::String>().Utf8Value();
   NSFontManager *font_manager = [NSFontManager sharedFontManager];
   FontPanelTarget *target = [[FontPanelTarget alloc] initWithEmitter:&emit];
   _target = target;
@@ -244,6 +243,8 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
   else
     [font_manager orderFrontFontPanel:window];
 
+  Napi::Object obj = Napi::Object::New(env);
+  deferred.Resolve(obj);
   return deferred.Promise();
 }
 

--- a/src/mac_font_manager.mm
+++ b/src/mac_font_manager.mm
@@ -222,7 +222,10 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
 
   Napi::Function emit(info[0].As<Napi::Function>());
   Napi::Object options = info[1].As<Napi::Object>();
-  bool show_styles = options.Get("showStyle").ToBoolean().Value();
+  bool show_styles = false;
+  Napi::Value showValue = options.Get("showStyle");
+  if (showValue.IsBoolean())
+    show_styles = showValue.ToBoolean().Value();
   std::string title;
   Napi::Value titleValue = options.Get("title");
   if (titleValue.IsString())

--- a/src/mac_font_manager.mm
+++ b/src/mac_font_manager.mm
@@ -38,6 +38,37 @@ NSFontTraitMask ParseTraits(Napi::Array traits) {
   return mask;
 }
 
+Napi::Array BuildTraits(Napi::Env env, NSFontTraitMask mask) {
+    std::vector<std::string> traits;
+    if ((NSBoldFontMask & mask) != 0)
+        traits.push_back("bold");
+    if ((NSCondensedFontMask & mask) != 0)
+        traits.push_back("condensed");
+    if ((NSExpandedFontMask & mask) != 0)
+        traits.push_back("expanded");
+    if ((NSFixedPitchFontMask & mask) != 0)
+        traits.push_back("fixedPitch");
+    if ((NSItalicFontMask & mask) != 0)
+        traits.push_back("italic");
+    if ((NSNarrowFontMask & mask) != 0)
+        traits.push_back("narrow");
+    if ((NSNonStandardCharacterSetFontMask & mask) != 0)
+        traits.push_back("nonStandardCharacterSet");
+    if ((NSPosterFontMask & mask) != 0)
+        traits.push_back("poster");
+    if ((NSSmallCapsFontMask & mask) != 0)
+        traits.push_back("smallCaps");
+    if ((NSUnboldFontMask & mask) != 0)
+        traits.push_back("unbold");
+    if ((NSUnitalicFontMask & mask) != 0)
+        traits.push_back("unitalic");
+    Napi::Array t = Napi::Array::New(env, traits.size());
+    for (size_t i = 0; i < traits.size(); i++)
+        t[i] = traits[i];
+
+    return t;
+}
+
 /***** EXPORTED FUNCTIONS *****/
 
 Napi::Array GetAvailableFonts(const Napi::CallbackInfo &info) {
@@ -98,7 +129,7 @@ Napi::Array GetAvailableMembersOfFontFamily(const Napi::CallbackInfo &info) {
     for (int j = 0; j < 3; j++) {
       if (j == 2)
         member[j] = [[family_member objectAtIndex:j] intValue]; // font weight
-      else 
+      else
         member[j] = std::string([[family_member objectAtIndex:j] UTF8String]);
     }
     members[i] = member;
@@ -107,14 +138,83 @@ Napi::Array GetAvailableMembersOfFontFamily(const Napi::CallbackInfo &info) {
   return members;
 }
 
-void ShowFontPanel(const Napi::CallbackInfo &info) {
-  bool show_styles = info[0].As<Napi::Boolean>().Value();
-  NSFontManager *font_manager = [NSFontManager sharedFontManager];
+@interface FontPanelTarget: NSObject
+{
+}
 
+@property (assign) Napi::FunctionReference* emit;
+@property (retain) NSFont* font;
+
+@end
+
+@implementation FontPanelTarget
+
+- (nullable instancetype)initWithEmitter:(Napi::Function*)emit
+{
+    self = [super init];
+    if (self != nil)
+    {
+        self.emit = new Napi::FunctionReference;
+        *self.emit = Napi::Persistent(*emit);
+        self.font = [NSFont boldSystemFontOfSize:12];
+    }
+
+    return self;
+}
+
+- (void)dealloc
+{
+    if (self.emit) {
+        Napi::Env env = self.emit->Env();
+        Napi::HandleScope scope(env);
+        delete self.emit;
+    }
+    [super dealloc];
+}
+
+- (void)changeFont:(id)sender
+{
+    self.font = [sender convertFont:self.font];
+
+    Napi::Env env = self.emit->Env();
+    Napi::HandleScope scope(env);
+    Napi::Object obj = Napi::Object::New(env);
+    obj.Set(Napi::String::New(env, "family"), Napi::String::New(env, [self.font.familyName UTF8String]));
+    obj.Set(Napi::String::New(env, "name"), Napi::String::New(env, [self.font.fontName UTF8String]));
+    obj.Set(Napi::String::New(env, "pointSize"), Napi::Number::New(env, self.font.pointSize));
+    NSFontTraitMask mask = self.font.fontDescriptor.symbolicTraits;
+    obj.Set(Napi::String::New(env, "traits"), BuildTraits(env, mask));
+    self.emit->Call({Napi::String::New(env, "fontSelected"), obj});
+}
+
+@end
+
+FontPanelTarget* _target = nil;
+
+Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
+
+  Napi::Function emit(info[0].As<Napi::Function>());
+  Napi::Object options = info[1].As<Napi::Object>();
+  bool show_styles = options.Get("showStyle").As<Napi::Boolean>().Value();
+  std::string title;
+  Napi::Value titleValue = options.Get("title");
+  if (titleValue.IsString())
+      title = titleValue.As<Napi::String>().Utf8Value();
+  NSFontManager* font_manager = [NSFontManager sharedFontManager];
+  FontPanelTarget* target = [[FontPanelTarget alloc] initWithEmitter:&emit];
+  _target = target;
+  [font_manager setTarget:target];
+  [font_manager setDelegate:target];
+
+  NSWindow *window = [[NSApplication sharedApplication] keyWindow];
   if (show_styles)
-    [font_manager orderFrontStylesPanel:nil];
+    [font_manager orderFrontStylesPanel:window];
   else
-    [font_manager orderFrontFontPanel:nil];
+    [font_manager orderFrontFontPanel:window];
+
+  return deferred.Promise();
 }
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {

--- a/src/win_font_manager.cc
+++ b/src/win_font_manager.cc
@@ -155,16 +155,20 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
   std::u16string title;
   Napi::Value titleValue = options.Get("title");
   if (titleValue.IsString())
-      title = titleValue.As<Napi::String>().Utf16Value();
+    title = titleValue.As<Napi::String>().Utf16Value();
   DWORD flags = CF_SCREENFONTS | CF_SCALABLEONLY;
 
   LOGFONTW logFont;
   memset(&logFont, 0, sizeof(logFont));
 
+  HWND parentHWND = NULL;
+  Napi::Value parentValue = options.Get("parent");
+  if (parentValue.IsBuffer() && parentValue.As<Napi::Buffer>().Length() == sizeof(HWND))
+    parentHWND = *(HWND*)parentValue.As<Napi::Buffer>().Data();
   CHOOSEFONTW chooseFontStruct;
   memset(&chooseFontStruct, 0, sizeof(chooseFontStruct));
   chooseFontStruct.lStructSize = sizeof(CHOOSEFONTW);
-  chooseFontStruct.hwndOwner = GetTopWindow(NULL);
+  chooseFontStruct.hwndOwner = parentHWND;
   chooseFontStruct.lpLogFont = &logFont;
   Napi::Value familyValue = options.Get("family");
   if (familyValue.IsString()) {

--- a/src/win_font_manager.cc
+++ b/src/win_font_manager.cc
@@ -186,9 +186,13 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
     flags |= CF_USESTYLE;
   }
   Napi::Value pointSizeValue = options.Get("pointSize");
-  // In 1/10s of a point
-  if (pointSizeValue.IsNumber())
-    chooseFontStruct.iPointSize = (INT)(pointSizeValue.As<Napi::Number>().DoubleValue() * 10.0);
+  if (pointSizeValue.IsNumber()) {
+    double pointSize = pointSizeValue.As<Napi::Number>().DoubleValue();
+    HDC hDC = GetDC(parentHWND);
+    logFont.lfHeight = INT(-pointSize * GetDeviceCaps(hDC, LOGPIXELSY) / 72);
+    // In 1/10s of a point
+    chooseFontStruct.iPointSize = (INT)(pointSize * 10.0);
+  }
   Napi::Value traitsIn = options.Get("traits");
   if (traitsIn.IsArray()) {
     Napi::Array traits = traitsIn.As<Napi::Array>();

--- a/src/win_font_manager.cc
+++ b/src/win_font_manager.cc
@@ -163,8 +163,8 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
 
   HWND parentHWND = NULL;
   Napi::Value parentValue = options.Get("parent");
-  if (parentValue.IsBuffer() && parentValue.As<Napi::Buffer>().Length() == sizeof(HWND))
-    parentHWND = *(HWND*)parentValue.As<Napi::Buffer>().Data();
+  if (parentValue.IsBuffer() && parentValue.As<Napi::Buffer<HWND>>().Length() == 1)
+    parentHWND = *parentValue.As<Napi::Buffer<HWND>>().Data();
   CHOOSEFONTW chooseFontStruct;
   memset(&chooseFontStruct, 0, sizeof(chooseFontStruct));
   chooseFontStruct.lStructSize = sizeof(CHOOSEFONTW);

--- a/src/win_font_manager.cc
+++ b/src/win_font_manager.cc
@@ -1,5 +1,46 @@
 #include <napi.h>
 
+/***** EXPORTED FUNCTIONS *****/
+
+int CALLBACK EnumFontFamExProc(
+   const LOGFONT    *lpelfe,
+   const TEXTMETRIC *lpntme,
+         DWORD      FontType,
+         LPARAM     lParam
+)
+{
+  const ENUMLOGFONTEX* logFont = (ENUMLOGFONTEX*)lpelfe;
+  std::vector<ENUMLOGFONTEX>* results = (std::vector<ENUMLOGFONTEX>*)lParam;
+  if (FontType == TRUETYPE_FONTTYPE)
+  {
+    results->append(lParam);
+    logFont->elfFullName;
+    logFont->elfStyle;
+  }
+}
+
+Napi::Array GetAvailableFonts(const Napi::CallbackInfo &info) {
+  LOGFONT logFont;
+  std::vector<ENUMLOGFONTEX> results;
+
+  // To enumerate all styles and charsets of all fonts:
+  lf.lfFaceName[0] = '\0';
+  lf.lfCharSet = DEFAULT_CHARSET;
+  int result = EnumFontFamiliesExW(
+                        hdc,
+                        &logFont,
+                        EnumFontFamExProc,
+                        (LPARAM)&results,
+                        0);
+  Napi::Array font_families = Napi::Array::New(env, results.size());
+  for (std::vector<ENUMLOGFONTEX>::iterator i = results.begin();
+       i != results.end();
+       ++) {
+    font_families[i] = results[i]->elfFullName;
+    font_families[i] = results[i]->elfStyle;
+  }
+}
+
 Napi::Array GetAvailableFontFamilies(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   Napi::Array font_families = Napi::Array::New(env, num_font_families);
@@ -23,9 +64,54 @@ Napi::Array GetAvailableFontFamilies(const Napi::CallbackInfo &info) {
   return font_families;
 }
 
+Napi::Array GetAvailableMembersOfFontFamily(const Napi::CallbackInfo &info) {
+  // To enumerate all styles and character sets of the Arial font:
+  hr = StringCchCopy((LPSTR)lf.lfFaceName, LF_FACESIZE, "Arial");
+  if (FAILED(hr))
+  {
+    // TODO: write error handler
+  }
+  lf.lfCharSet = DEFAULT_CHARSET;
+}
+
+void ShowFontPanel(const Napi::CallbackInfo &info) {
+  bool show_styles = info[0].As<Napi::Boolean>().Value();
+  // It should be OK to always use GDI simulations
+  DWORD flags = CF_SCREENFONTS /* | CF_NOSIMULATIONS */ ;
+
+  LOGFONT logFont;
+
+  CHOOSEFONT chooseFontStruct;
+  chooseFontStruct.lStructSize = sizeof(CHOOSEFONT);
+  chooseFontStruct.hwndOwner = GetTopWindow(NULL);
+  chooseFontStruct.lpLogFont = &logFont;
+
+  if ( m_fontData.GetRestrictSelection() & wxFONTRESTRICT_SCALABLE )
+    flags |= CF_SCALABLEONLY;
+  chooseFontStruct.Flags = flags;
+  if ( ChooseFont(&chooseFontStruct) != 0 )
+  {
+    wxRGBToColour(m_fontData.m_fontColour, chooseFontStruct.rgbColors);
+    m_fontData.m_chosenFont = wxFont(wxNativeFontInfo(logFont, this));
+    m_fontData.EncodingInfo().facename = logFont.lfFaceName;
+    m_fontData.EncodingInfo().charset = logFont.lfCharSet;
+
+    return wxID_OK;
+  }
+}
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set(
+    Napi::String::New(env, "getAvailableFonts"), Napi::Function::New(env, GetAvailableFonts)
+  );
+  exports.Set(
     Napi::String::New(env, "getAvailableFontFamilies"), Napi::Function::New(env, GetAvailableFontFamilies)
+  );
+  exports.Set(
+    Napi::String::New(env, "getAvailableMembersOfFontFamily"), Napi::Function::New(env, GetAvailableMembersOfFontFamily)
+  );
+  exports.Set(
+    Napi::String::New(env, "showFontPanel"), Napi::Function::New(env, ShowFontPanel)
   );
 
   return exports;

--- a/src/win_font_manager.cc
+++ b/src/win_font_manager.cc
@@ -165,7 +165,7 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
   // }
 
   CHOOSEFONTW chooseFontStruct;
-  memset(&chooseFontStruct, sizeof(chooseFontStruct));
+  memset(&chooseFontStruct, 0, sizeof(chooseFontStruct));
   chooseFontStruct.lStructSize = sizeof(CHOOSEFONTW);
   chooseFontStruct.hwndOwner = GetTopWindow(NULL);
   chooseFontStruct.lpLogFont = &logFont;
@@ -188,12 +188,12 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
       std::vector<std::string> traits;
       if ((chooseFontStruct.nFontType & BOLD_FONTTYPE) != 0)
           traits.push_back("bold");
-      if ((chooseFontStruct.nFontType & ITALICS_FONTTYPE) != 0)
+      if ((chooseFontStruct.nFontType & ITALIC_FONTTYPE) != 0)
           traits.push_back("italic");
       Napi::Array t = Napi::Array::New(env, traits.size());
       for (size_t i = 0; i < traits.size(); i++)
           t[i] = traits[i];
-      obj.Set(Napi::String::New(env, "traits"), BuildTraits(env, mask));
+      obj.Set(Napi::String::New(env, "traits"), t);
       emit.Call({Napi::String::New(env, "fontSelected"), obj});
       deferred.Resolve(obj);
   }

--- a/src/win_font_manager.cc
+++ b/src/win_font_manager.cc
@@ -212,7 +212,7 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
               Napi::String::New(env, (const char16_t*)chooseFontStruct.lpszStyle));
     // In 1/10s of a point
     obj.Set("pointSize",
-            Napi::Number::New(env, (double)chooseFontStruct.iPointSize) / 10.0);
+            Napi::Number::New(env, (double)chooseFontStruct.iPointSize / 10.0));
     std::vector<std::string> traits;
     if ((chooseFontStruct.nFontType & BOLD_FONTTYPE) != 0)
       traits.push_back("bold");

--- a/src/win_font_manager.cc
+++ b/src/win_font_manager.cc
@@ -186,7 +186,7 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
     chooseFontStruct.iPointSize = (INT)pointSizeValue.As<Napi::Number>().Int32Value();
   Napi::Value traitsIn = options.Get("traits");
   if (traitsIn.IsArray()) {
-    Napi::Array traits = traits.As<Napi::Array>();
+    Napi::Array traits = traitsIn.As<Napi::Array>();
     int traits_length = static_cast<int>(traits.Length());
     for (int i = 0; i < traits_length; i++) {
       std::string trait = traits.Get(i).As<Napi::String>().Utf8Value();

--- a/src/win_font_manager.cc
+++ b/src/win_font_manager.cc
@@ -183,7 +183,8 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
   {
       Napi::Object obj = Napi::Object::New(env);
       obj.Set("family", Napi::String::New(env, (const char16_t*)logFont.lfFaceName));
-      obj.Set("style", Napi::String::New(env, (const char16_t*)chooseFontStruct.lpszStyle));
+      if (chooseFontStruct.lpszStyle)
+          obj.Set("style", Napi::String::New(env, (const char16_t*)chooseFontStruct.lpszStyle));
       obj.Set("pointSize", Napi::Number::New(env, chooseFontStruct.iPointSize));
       std::vector<std::string> traits;
       if ((chooseFontStruct.nFontType & BOLD_FONTTYPE) != 0)

--- a/src/win_font_manager.cc
+++ b/src/win_font_manager.cc
@@ -156,7 +156,7 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
   Napi::Value titleValue = options.Get("title");
   if (titleValue.IsString())
     title = titleValue.As<Napi::String>().Utf16Value();
-  DWORD flags = CF_SCREENFONTS | CF_SCALABLEONLY;
+  DWORD flags = CF_SCREENFONTS | CF_SCALABLEONLY | CF_EFFECTS;
 
   LOGFONTW logFont;
   memset(&logFont, 0, sizeof(logFont));
@@ -235,7 +235,7 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
   }
   else
   {
-    deferred.Reject(Napi::String::New(env, "user cancel"));
+    deferred.Reject(Napi::Error::New(env, "cancel"));
   }
   return deferred.Promise();
 }

--- a/src/win_font_manager.cc
+++ b/src/win_font_manager.cc
@@ -235,7 +235,7 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
   }
   else
   {
-    deferred.Reject(Napi::Error::New(env, "cancel"));
+    deferred.Reject(Napi::Error::New(env, "cancel").Value());
   }
   return deferred.Promise();
 }

--- a/src/win_font_manager.cc
+++ b/src/win_font_manager.cc
@@ -168,21 +168,23 @@ Napi::Value ShowFontPanel(const Napi::CallbackInfo &info) {
   chooseFontStruct.lpLogFont = &logFont;
   Napi::Value familyValue = options.Get("family");
   if (familyValue.IsString()) {
-    StringCchCopyW(logFont.lfFaceName, LF_FACESIZE, familyValue.As<Napi::String>().Utf16Value());
+    std::u16string s(familyValue.As<Napi::String>().Utf16Value());
+    StringCchCopyW(logFont.lfFaceName, LF_FACESIZE, (const WCHAR*)s.c_str());
     flags |= CF_INITTOLOGFONTSTRUCT;
   }
-  std::vector<TCHAR> styleBuf;
+  std::vector<WCHAR> styleBuf;
   Napi::Value styleValue = options.Get("style");
   if (styleValue.IsString()) {
     styleBuf.resize(LF_FACESIZE);
     chooseFontStruct.lpszStyle = &styleBuf[0];
-    StringCchCopyW(chooseFontStruct.lpszStyle, LF_FACESIZE, styleValue.As<Napi::String>().Utf16Value());
+    std::u16string s(styleValue.As<Napi::String>().Utf16Value());
+    StringCchCopyW(chooseFontStruct.lpszStyle, LF_FACESIZE, (const WCHAR*)s.c_str());
     flags |= CF_USESTYLE;
   }
   Napi::Value pointSizeValue = options.Get("pointSize");
   if (pointSizeValue.IsNumber())
     chooseFontStruct.iPointSize = (INT)pointSizeValue.As<Napi::Number>().Int32Value();
-  Nap::Value traitsIn = options.Get("traits");
+  Napi::Value traitsIn = options.Get("traits");
   if (traitsIn.IsArray()) {
     Napi::Array traits = traits.As<Napi::Array>();
     int traits_length = static_cast<int>(traits.Length());

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1,9 +1,9 @@
 const { expect } = require('chai')
-const { 
+const {
   getAvailableFontFamilies,
   getAvailableMembersOfFontFamily,
   getAvailableFonts,
-  showFontPanel
+  FontPanel
 } = require('../index')
 
 describe('electron-font-manager', () => {
@@ -58,10 +58,11 @@ describe('electron-font-manager', () => {
     })
   })
 
-  describe('showFontPanel(showStyles)', () => {
+  describe('FontPanel.show({ showStyles })', () => {
     it('should throw if showStyles is not a boolean', () => {
       expect(() => {
-        showFontPanel('hello')
+        const panel = new FontPanel();
+        panel.show({ showStyles: 'hello' });
       }).to.throw(/showStyles must be a boolean/)
     })
   })


### PR DESCRIPTION
Implements #14 
Also implements Windows font enumeration #1 and possibly fixes #8 (Windows code did not compile)

I'm not sure if this project is active but I've been working on font dialog support for Mac and Windows (I have not looked at GTK.)  I changed showFontPanel considerably to deal with the modeless font panel on Mac, opting to turn it into an event emitter.  Maybe this is useful to someone.
